### PR TITLE
merge env variables with server.env

### DIFF
--- a/src/mcpcli/transport/stdio/stdio_client.py
+++ b/src/mcpcli/transport/stdio/stdio_client.py
@@ -30,7 +30,7 @@ async def stdio_client(server: StdioServerParameters):
     # start the subprocess
     process = await anyio.open_process(
         [server.command, *server.args],
-        env=server.env or get_default_environment(),
+        env={**get_default_environment(), **(server.env or {})},
         stderr=sys.stderr,
     )
 


### PR DESCRIPTION
fix issue loading env variables when server.env is in server_config.json
When setting BRAVE_API_KEY in server_config, PATH is ignored.