### PR TITLE
Anthropic support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=mykey
+ANTHROPIC_API_KEY=mykey

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "requests>=2.32.3",
     "rich>=13.9.4",
+    "anthropic>=0.19.2",
 ]
 [project.scripts]
 mcp-cli = "mcpcli.__main__:cli_main"

--- a/src/mcpcli/__main__.py
+++ b/src/mcpcli/__main__.py
@@ -340,20 +340,23 @@ def cli_main():
 
     parser.add_argument(
         "--provider",
-        choices=["openai", "ollama"],
+        choices=["openai", "anthropic", "ollama"],
         default="openai",
         help="LLM provider to use. Defaults to 'openai'.",
     )
 
     parser.add_argument(
         "--model",
-        help=("Model to use. Defaults to 'gpt-4o-mini' for 'openai' and 'qwen2.5-coder' for 'ollama'."),
+        help=("Model to use. Defaults to 'gpt-4o-mini' for openai, 'claude-3-5-haiku-latest' for anthropic and 'qwen2.5-coder' for ollama"),
     )
 
     args = parser.parse_args()
 
+    # Set default model based on provider
     model = args.model or (
-        "gpt-4o-mini" if args.provider == "openai" else "qwen2.5-coder"
+        "gpt-4o-mini" if args.provider == "openai"
+        else "claude-3-5-haiku-latest" if args.provider == "anthropic"
+        else "qwen2.5-coder"
     )
     os.environ["LLM_PROVIDER"] = args.provider
     os.environ["LLM_MODEL"] = model

--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -153,6 +153,7 @@ def convert_to_openai_tools(tools):
             "type": "function",
             "function": {
                 "name": tool["name"],
+                "description": tool.get("description", ""),
                 "parameters": tool.get("inputSchema", {}),
             },
         }

--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -16,6 +16,7 @@ def parse_tool_response(response: str) -> Optional[Dict[str, Any]]:
         try:
             args = json.loads(args_string)
             return {
+                "id": f"call_{function_name}",
                 "function": function_name,
                 "arguments": args,
             }
@@ -30,6 +31,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
     This function no longer prints directly to stdout. It updates the conversation_history
     with the tool call and its response. The calling function can then display the results.
     """
+    tool_call_id = None
     tool_name = "unknown_tool"
     raw_arguments = {}
 
@@ -40,9 +42,11 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
         ):
             # Get tool name and arguments based on format
             if hasattr(tool_call, "function"):
+                tool_call_id = tool_call.id
                 tool_name = tool_call.function.name
                 raw_arguments = tool_call.function.arguments
             else:
+                tool_call_id = tool_call["id"]
                 tool_name = tool_call["function"]["name"]
                 raw_arguments = tool_call["function"]["arguments"]
         else:
@@ -53,6 +57,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 logging.debug("Unable to parse tool call from message")
                 return
 
+            tool_call_id = parsed_tool["id"]
             tool_name = parsed_tool["function"]
             raw_arguments = parsed_tool["arguments"]
 
@@ -88,7 +93,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 "content": None,
                 "tool_calls": [
                     {
-                        "id": f"call_{tool_name}",
+                        "id": tool_call_id,
                         "type": "function",
                         "function": {
                             "name": tool_name,
@@ -107,7 +112,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 "role": "tool",
                 "name": tool_name,
                 "content": formatted_response,
-                "tool_call_id": f"call_{tool_name}",
+                "tool_call_id": tool_call_id,
             }
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,24 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/d9/c39005f04c602607d68d48d1c917b35af8d16b687b7ca427ca787c39d8b9/anthropic-0.40.0.tar.gz", hash = "sha256:3efeca6d9e97813f93ed34322c6c7ea2279bf0824cd0aa71b59ce222665e2b87", size = 190939 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/18/a68cfb9a11990377650c36c25b5dfb0baece900e9e505b68e1aa06ad0227/anthropic-0.40.0-py3-none-any.whl", hash = "sha256:442028ae8790ff9e3b6f8912043918755af1230d193904ae2ef78cc22995280c", size = 199484 },
+]
+
+[[package]]
 name = "anyio"
 version = "4.6.2.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -205,6 +223,7 @@ name = "mcp-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "anyio" },
     { name = "asyncio" },
     { name = "ollama" },
@@ -223,6 +242,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.19.2" },
     { name = "anyio", specifier = ">=4.6.2.post1" },
     { name = "asyncio", specifier = ">=3.4.3" },
     { name = "ollama", specifier = ">=0.4.2" },


### PR DESCRIPTION
This adds support for the Anthropic API to talk to the Claude models.

It uses the official anthropic python sdk and the prompt caching feature to reduce costs.
Due to the API differences the OpenAI compatible message payloads are converted to and from Anthropic payloads.

I have tested this with the `claude-3-5-haiku-latest` (default) and `claude-3-5-sonnet-latest` models.

To use this specify `--provider anthropic` and set the `ANTHROPIC_API_KEY` environment variable to a valid api key.