### PR TITLE
Fix endless loop if MCP command fails

### DIFF
--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -72,9 +72,8 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 break
         if tool_response.get("isError"):
             logging.debug(
-                f"Error calling tool '{tool_name}': {tool_response.get('error')}"
+                f"Error calling tool '{tool_name}': {tool_response.get('content')}"
             )
-            return
 
         # Format the tool response
         formatted_response = format_tool_response(tool_response.get("content", []))


### PR DESCRIPTION
Without this fix mcp-cli retries the last command in an endless loop if it failed, for example accessing a directory outisde the allowed directories with the filesystem demo MCP server.