### PR TITLE
removed auto exit upon no tools being configured

### DIFF
--- a/src/mcpcli/chat_handler.py
+++ b/src/mcpcli/chat_handler.py
@@ -18,11 +18,8 @@ async def handle_chat_mode(server_streams, provider="openai", model="gpt-4o-mini
         for read_stream, write_stream in server_streams:
             tools.extend(await fetch_tools(read_stream, write_stream))
 
-        # for (read_stream, write_stream) in server_streams:
-        # tools = await fetch_tools(read_stream, write_stream)
         if not tools:
-            print("[red]No tools available. Exiting chat mode.[/red]")
-            return
+            print("[red]No tools are available.[/red]")
 
         system_prompt = generate_system_prompt(tools)
         openai_tools = convert_to_openai_tools(tools)


### PR DESCRIPTION
-No need to keep dead code.
-Left output as a warning but removed exit logic.
  -This isn't an error and doesn't require exiting chat.  It's possible to configure it without tools.  While perhaps vexing, not an error.
  -Might even want to remove the feedback.
  -Might want to better explain to user why absence of tools is being called out.