### PR TITLE
Fix for Loop on multiple servers #32 

### DIFF
--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -86,7 +86,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 continue
 
         if tool_response.get("isError"):
-             logging.debug(
+            logging.debug(
                 f"Error calling tool '{tool_name}': {tool_response.get('content')}"
             )
 

--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -86,7 +86,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
                 continue
 
         if tool_response.get("isError"):
-            print(
+             logging.debug(
                 f"Error calling tool '{tool_name}': {tool_response.get('content')}"
             )
 

--- a/src/mcpcli/tools_handler.py
+++ b/src/mcpcli/tools_handler.py
@@ -68,7 +68,7 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
             else raw_arguments
         )
 
-        # Call the tool (no direct print here)       
+        # Call the tool (no direct print here)
         for read_stream, write_stream in server_streams:
             tools = await fetch_tools(read_stream, write_stream)
             server_has_tool = False
@@ -89,7 +89,6 @@ async def handle_tool_call(tool_call, conversation_history, server_streams):
             logging.debug(
                 f"Error calling tool '{tool_name}': {tool_response.get('content')}"
             )
-
 
         # Format the tool response
         formatted_response = format_tool_response(tool_response.get("content", []))


### PR DESCRIPTION
This addresses issue #32 where the llm was looping when a tool was execucuted that was not in the first mcp-server in the list.
This PR checks for the available tools in loop iteration and only executes the tool call when the tool fits to the current server.